### PR TITLE
Task8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'jquery-rails'
 gem 'rubocop', require: false
 gem 'carrierwave'
 gem 'remotipart'
-#gem 'cocoon'
+gem 'cocoon'
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,9 @@ gem 'devise-i18n-views'
 gem 'jquery-turbolinks'
 gem 'jquery-rails'
 gem 'rubocop', require: false
-#gem 'carrierwave'
-#gem 'remotipart'
-#gem "cocoon"
+gem 'carrierwave'
+gem 'remotipart'
+#gem 'cocoon'
 
 
 group :development, :test do

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require jquery.remotipart
 // require rails-ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery.remotipart
-// require rails-ujs
 //= require turbolinks
+//= require cocoon
 //= require_tree .

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -49,6 +49,6 @@ class AnswersController < ApplicationController
   end
 
   def answer_params
-    params.require(:answer).permit(:question_id, :body)
+    params.require(:answer).permit(:question_id, :body, attachments_attributes: [:file])
   end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,0 +1,19 @@
+class AttachmentsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :load_attachment
+
+  def destroy
+    if current_user.author_of?(@attachment.attachable)
+      @attachment.destroy!
+      flash_message :success, "Файл успешно удален."
+    else
+      flash_message :error, "Вы не можете удалять чужие файлы."
+    end
+  end
+
+  private
+
+  def load_attachment
+    @attachment = Attachment.find(params[:id])
+  end
+end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -8,6 +8,7 @@ class QuestionsController < ApplicationController
 
   def show
     @answer = Answer.new
+    @answer.attachments.build
   end
 
   def new

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -12,6 +12,7 @@ class QuestionsController < ApplicationController
 
   def new
     @question = Question.new
+    @question.attachments.build
   end
 
   def edit
@@ -51,6 +52,6 @@ class QuestionsController < ApplicationController
   end
 
   def question_params
-    params.require(:question).permit(:title, :body)
+    params.require(:question).permit(:title, :body, attachments_attributes: [:file])
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -5,13 +5,13 @@ class Answer < ApplicationRecord
 
   validates :body, presence: true
 
-  accepts_nested_attributes_for :attachments
+  accepts_nested_attributes_for :attachments, reject_if: :all_blank
 
   default_scope { order(accept: :desc, id: :asc) }
 
   def accept!
     transaction do
-      question.answers.update_all(accept: false)
+      question.answers.where('id != ?', id).update_all(accept: false)
       update!(accept: true)
     end
   end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,8 +1,11 @@
 class Answer < ApplicationRecord
   belongs_to :user
   belongs_to :question
+  has_many :attachments, as: :attachable, dependent: :destroy
 
   validates :body, presence: true
+
+  accepts_nested_attributes_for :attachments
 
   default_scope { order(accept: :desc, id: :asc) }
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,0 +1,3 @@
+class Attachment < ApplicationRecord
+  belongs_to :attachable, polymorphic: true, optional: true
+end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,3 +1,5 @@
 class Attachment < ApplicationRecord
   belongs_to :attachable, polymorphic: true, optional: true
+
+  mount_uploader :file, FileUploader
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,4 +1,6 @@
 class Attachment < ApplicationRecord
+  delegate :identifier, to: :file
+
   belongs_to :attachable, polymorphic: true, optional: true
 
   mount_uploader :file, FileUploader

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,6 @@
 class Attachment < ApplicationRecord
   delegate :identifier, to: :file
+  delegate :filename, to: :file
 
   belongs_to :attachable, polymorphic: true, optional: true
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,7 +1,4 @@
 class Attachment < ApplicationRecord
-  delegate :identifier, to: :file
-  delegate :filename, to: :file
-
   belongs_to :attachable, polymorphic: true, optional: true
 
   mount_uploader :file, FileUploader

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,5 +5,5 @@ class Question < ApplicationRecord
 
   validates :title, :body, presence: true
 
-  accepts_nested_attributes_for :attachments
+  accepts_nested_attributes_for :attachments, reject_if: :all_blank
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,6 @@ class Question < ApplicationRecord
   has_many :attachments, as: :attachable, dependent: :destroy
 
   validates :title, :body, presence: true
-  
+
   accepts_nested_attributes_for :attachments
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,9 @@
 class Question < ApplicationRecord
   belongs_to :user
   has_many :answers, dependent: :destroy
+  has_many :attachments, as: :attachable, dependent: :destroy
 
   validates :title, :body, presence: true
+  
+  accepts_nested_attributes_for :attachments
 end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -1,0 +1,49 @@
+class FileUploader < CarrierWave::Uploader::Base
+
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+
+end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -1,4 +1,6 @@
 class FileUploader < CarrierWave::Uploader::Base
+  delegate :identifier, to: :file, allow_nil: true
+
   storage :file
 
   def store_dir

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -1,49 +1,7 @@
 class FileUploader < CarrierWave::Uploader::Base
-
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
   storage :file
-  # storage :fog
 
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
-
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
-
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
-
 end

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -4,6 +4,11 @@
       span.accept
     p
       | [#{answer.id}] #{answer.body}
+    p
+      ' Attachments:
+      - answer.attachments.each do |a|
+        li= link_to a.file.file.identifier, a.file.url
+        
     - if current_user&.author_of?(answer)
       = form_for answer, method: :patch, remote: true do |f|
         = render 'shared/form_error', object: f.object

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -7,8 +7,8 @@
     p
       ' Attachments:
       - answer.attachments.each do |a|
-        li= link_to a.file.file.identifier, a.file.url
-        
+        li= link_to a.file.identifier, a.file.url
+
     - if current_user&.author_of?(answer)
       = form_for answer, method: :patch, remote: true do |f|
         = render 'shared/form_error', object: f.object

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -7,13 +7,7 @@
     p
       #answer_attachments
         h5 Attachments:
-        - answer.attachments.each do |a|
-          div id="attachment#{a.id}"
-            li
-              = link_to a.file.filename, a.file.url
-              - if current_user&.author_of?(answer)
-                '
-                = link_to 'remove file', a, method: :delete, remote: true
+        = render answer.attachments
 
     - if current_user&.author_of?(answer)
       = form_for answer, method: :patch, remote: true do |f|

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -5,9 +5,15 @@
     p
       | [#{answer.id}] #{answer.body}
     p
-      ' Attachments:
-      - answer.attachments.each do |a|
-        li= link_to a.file.identifier, a.file.url
+      #answer_attachments
+        h5 Attachments:
+        - answer.attachments.each do |a|
+          div id="attachment#{a.id}"
+            li
+              = link_to a.file.filename, a.file.url
+              - if current_user&.author_of?(answer)
+                '
+                = link_to 'remove file', a, method: :delete, remote: true
 
     - if current_user&.author_of?(answer)
       = form_for answer, method: :patch, remote: true do |f|

--- a/app/views/attachments/_attachment.html.slim
+++ b/app/views/attachments/_attachment.html.slim
@@ -1,0 +1,6 @@
+div id="attachment#{attachment.id}"
+  li
+    = link_to attachment.file.identifier, attachment.file.url
+    - if current_user&.author_of?(attachment.attachable)
+      '
+      = link_to 'remove file', attachment, method: :delete, remote: true

--- a/app/views/attachments/destroy.js.erb
+++ b/app/views/attachments/destroy.js.erb
@@ -1,0 +1,5 @@
+<%= render 'layouts/flash_messages' %>
+
+<% if @attachment.errors.empty? %>
+  $("#attachment<%= @attachment.id %>").remove();
+<% end %>

--- a/app/views/questions/_attachment_fields.html.slim
+++ b/app/views/questions/_attachment_fields.html.slim
@@ -1,0 +1,4 @@
+.nested-fields
+  .field
+    = f.label :file
+    = f.file_field :file

--- a/app/views/questions/_attachment_fields.html.slim
+++ b/app/views/questions/_attachment_fields.html.slim
@@ -1,4 +1,8 @@
 .nested-fields
   .field
     = f.label :file
-    = f.file_field :file
+    - if f.object.persisted? && f.object.file.filename.present?
+      = link_to f.object.file.filename, f.object.file.url
+    - else
+      = f.file_field :file
+    = link_to_remove_association "remove file", f

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -10,7 +10,7 @@
     h4 Attachments:
     #attachments
       = f.fields_for :attachments do |attachment|
-        = render 'questions/attachment_fields', f: attachment
+        = render 'attachment_fields', f: attachment
         .links
           = link_to_add_association 'add file', f, :attachments
   p

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -7,10 +7,11 @@
     =f.label :body
     =f.text_area :body
   p
-    | Attachments:
-    br
-    = f.fields_for :attachments do |a|
-      = a.label :file
-      = a.file_field :file
+    h4 Attachments:
+    #attachments
+      = f.fields_for :attachments do |attachment|
+        = render 'questions/attachment_fields', f: attachment
+        .links
+          = link_to_add_association 'add file', f, :attachments
   p
     =f.submit "Create"

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -7,4 +7,10 @@
     =f.label :body
     =f.text_area :body
   p
+    | Attachments:
+    br
+    = f.fields_for :attachments do |a|
+      = a.label :file
+      = a.file_field :file
+  p
     =f.submit "Create"

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -46,4 +46,10 @@ javascript:
     =f.label :body
     =f.text_area :body
   p
+    | Attachments:
+    br
+    = f.fields_for :attachments do |a|
+      = a.label :file
+      = a.file_field :file
+  p
     =f.submit 'Ask answer'

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -17,13 +17,7 @@ javascript:
   p
     #attachments1
       h4 Attachments:
-      - @question.attachments.each do |a|
-        div id="attachment#{a.id}"
-          li
-            = link_to a.file.filename, a.file.url
-            - if current_user&.author_of?(@question)
-              '
-              = link_to 'remove file', a, method: :delete, remote: true
+      = render @question.attachments
 
   - if current_user&.author_of?(@question)
     =form_for @question, html: {id: "edit_question_#{@question.id}"}, remote: true do |f|

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -46,10 +46,12 @@ javascript:
     =f.label :body
     =f.text_area :body
   p
-    | Attachments:
-    br
-    = f.fields_for :attachments do |a|
-      = a.label :file
-      = a.file_field :file
+    h4 Attachments:
+    #attachments
+      = f.fields_for :attachments do |attachment|
+        = render 'attachment_fields', f: attachment
+        .links
+          = link_to_add_association 'add file', f, :attachments
+
   p
     =f.submit 'Ask answer'

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -15,9 +15,15 @@ javascript:
     = @question.body
 
   p
-    ' Attachments:
-    - @question.attachments.each do |a|
-      li= link_to a.file.file.filename, a.file.url
+    #attachments1
+      h4 Attachments:
+      - @question.attachments.each do |a|
+        div id="attachment#{a.id}"
+          li
+            = link_to a.file.filename, a.file.url
+            - if current_user&.author_of?(@question)
+              '
+              = link_to 'remove file', a, method: :delete, remote: true
 
   - if current_user&.author_of?(@question)
     =form_for @question, html: {id: "edit_question_#{@question.id}"}, remote: true do |f|
@@ -37,7 +43,7 @@ javascript:
 
 .answers
   p
-    | Answers:
+    h3 Answers:
     = render @question.answers
 
 = form_for [@question, @answer], remote: true do |f|
@@ -46,12 +52,11 @@ javascript:
     =f.label :body
     =f.text_area :body
   p
-    h4 Attachments:
+    h5 Attachments:
     #attachments
       = f.fields_for :attachments do |attachment|
         = render 'attachment_fields', f: attachment
         .links
           = link_to_add_association 'add file', f, :attachments
-
   p
     =f.submit 'Ask answer'

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -13,6 +13,12 @@ javascript:
   p
     ' Body:
     = @question.body
+
+  p
+    ' Attachments:
+    - @question.attachments.each do |a|
+      li= link_to a.file.file.identifier, a.file.url
+
   - if current_user&.author_of?(@question)
     =form_for @question, html: {id: "edit_question_#{@question.id}"}, remote: true do |f|
       = render 'shared/form_error', object: f.object

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -17,7 +17,7 @@ javascript:
   p
     ' Attachments:
     - @question.attachments.each do |a|
-      li= link_to a.file.identifier, a.file.url
+      li= link_to a.file.file.filename, a.file.url
 
   - if current_user&.author_of?(@question)
     =form_for @question, html: {id: "edit_question_#{@question.id}"}, remote: true do |f|

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -17,7 +17,7 @@ javascript:
   p
     ' Attachments:
     - @question.attachments.each do |a|
-      li= link_to a.file.file.identifier, a.file.url
+      li= link_to a.file.identifier, a.file.url
 
   - if current_user&.author_of?(@question)
     =form_for @question, html: {id: "edit_question_#{@question.id}"}, remote: true do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
       patch 'accept', on: :member
     end
   end
+  resources :attachments, only: [:destroy]
   root 'questions#index'
 end

--- a/db/migrate/20170616151439_create_attachments.rb
+++ b/db/migrate/20170616151439_create_attachments.rb
@@ -1,0 +1,12 @@
+class CreateAttachments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :attachments do |t|
+      t.string :file
+      t.integer :attachable_id
+      t.string :attachable_type
+
+      t.timestamps
+    end
+    add_index :attachments, [:attachable_id, :attachable_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170609115009) do
+ActiveRecord::Schema.define(version: 20170616151439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 20170609115009) do
     t.index ["accept"], name: "index_answers_on_accept"
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["user_id"], name: "index_answers_on_user_id"
+  end
+
+  create_table "attachments", force: :cascade do |t|
+    t.string "file"
+    t.integer "attachable_id"
+    t.string "attachable_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type"
   end
 
   create_table "questions", force: :cascade do |t|

--- a/spec/acceptance/answers/add_files_to_answer_spec.rb
+++ b/spec/acceptance/answers/add_files_to_answer_spec.rb
@@ -1,0 +1,23 @@
+require 'acceptance/acceptance_helper'
+
+feature 'Add files to answer', %q{
+  I order to be able illustrate my answer
+  As an authenticate user
+  I want to be add files to answer
+} do
+
+  given(:user) { create(:user)}
+  given(:question) { create(:question) }
+
+  scenario 'User add files to answer', js: true do
+    sign_in(user)
+
+    visit question_path(question)
+
+    fill_in 'Body', with: 'Body 1'
+    attach_file 'File', "#{Rails.root}/spec/spec_helper.rb"
+    click_on 'Ask answer'
+
+    expect(page).to have_link"spec_helper.rb", href: "/uploads/attachment/file/1/spec_helper.rb"
+  end
+end

--- a/spec/acceptance/answers/add_files_to_answer_spec.rb
+++ b/spec/acceptance/answers/add_files_to_answer_spec.rb
@@ -15,9 +15,16 @@ feature 'Add files to answer', %q{
     visit question_path(question)
 
     fill_in 'Body', with: 'Body 1'
-    attach_file 'File', "#{Rails.root}/spec/spec_helper.rb"
+    within(:xpath, "//div[@id='attachments']/div[@class='nested-fields'][1]/div[@class='field']") do
+      attach_file 'File', "#{Rails.root}/spec/spec_helper.rb"
+    end
+    click_on 'add file'
+    within(:xpath, "//div[@id='attachments']/div[@class='nested-fields'][2]/div[@class='field']") do
+      attach_file 'File', "#{Rails.root}/spec/rails_helper.rb"
+    end
     click_on 'Ask answer'
 
     expect(page).to have_link"spec_helper.rb", href: "/uploads/attachment/file/1/spec_helper.rb"
+    expect(page).to have_link"rails_helper.rb", href: "/uploads/attachment/file/2/rails_helper.rb"
   end
 end

--- a/spec/acceptance/answers/remove_files_from_answer_spec.rb
+++ b/spec/acceptance/answers/remove_files_from_answer_spec.rb
@@ -16,6 +16,7 @@ feature 'Remove files from answer', %q{
 
     within("div#answer_attachments > div#attachment1") do
       click_on 'remove file'
+      wait_for_ajax
     end
     expect(page).to_not have_link "spec_helper.rb"
   end

--- a/spec/acceptance/answers/remove_files_from_answer_spec.rb
+++ b/spec/acceptance/answers/remove_files_from_answer_spec.rb
@@ -1,0 +1,33 @@
+require 'acceptance/acceptance_helper'
+
+feature 'Remove files from answer', %q{
+  I order to be able remove file from my answer
+  As an author of answer
+  I want to be remove files from answer
+} do
+
+  given!(:user) { create(:user) }
+  given!(:answer) { create(:answer_with_attachments, count: 1) }
+
+  scenario 'Author delete files from answer', js: true do
+    sign_in(answer.user)
+
+    visit question_path(answer.question)
+
+    within("div#answer_attachments > div#attachment1") do
+      click_on 'remove file'
+    end
+    expect(page).to_not have_link "spec_helper.rb"
+  end
+
+  scenario 'Non-author can\'t delete files from answer', js: true do
+    expect(answer.user).to_not eq user
+    sign_in(user)
+
+    visit question_path(answer.question)
+
+    within("#answer_attachments") do
+      expect(page).to_not have_link"remove file"
+    end
+  end
+end

--- a/spec/acceptance/questions/add_files_to_question_spec.rb
+++ b/spec/acceptance/questions/add_files_to_question_spec.rb
@@ -8,16 +8,24 @@ feature 'Add files to question', %q{
 
   given(:user) { create(:user)}
 
-  scenario 'User add files to question' do
+  scenario 'User add files to question', js: true do
     sign_in(user)
 
     visit new_question_path
 
     fill_in 'Title', with: 'Title 1'
     fill_in 'Body', with: 'Body 1'
-    attach_file 'File', "#{Rails.root}/spec/spec_helper.rb"
+
+    within(:xpath, "//div[@id='attachments']/div[@class='nested-fields'][1]/div[@class='field']") do
+      attach_file 'File', "#{Rails.root}/spec/spec_helper.rb"
+    end
+    click_on 'add file'
+    within(:xpath, "//div[@id='attachments']/div[@class='nested-fields'][2]/div[@class='field']") do
+      attach_file 'File', "#{Rails.root}/spec/rails_helper.rb"
+    end
     click_on 'Create'
 
     expect(page).to have_link"spec_helper.rb", href: "/uploads/attachment/file/1/spec_helper.rb"
+    expect(page).to have_link"rails_helper.rb", href: "/uploads/attachment/file/2/rails_helper.rb"
   end
 end

--- a/spec/acceptance/questions/add_files_to_question_spec.rb
+++ b/spec/acceptance/questions/add_files_to_question_spec.rb
@@ -1,0 +1,23 @@
+require 'acceptance/acceptance_helper'
+
+feature 'Add files to question', %q{
+  I order to be able illustrate my question
+  As an authenticate user
+  I want to be add files to question
+} do
+
+  given(:user) { create(:user)}
+
+  scenario 'User add files to question' do
+    sign_in(user)
+
+    visit new_question_path
+
+    fill_in 'Title', with: 'Title 1'
+    fill_in 'Body', with: 'Body 1'
+    attach_file 'File', "#{Rails.root}/spec/spec_helper.rb"
+    click_on 'Create'
+
+    expect(page).to have_link"spec_helper.rb", href: "/uploads/attachment/file/1/spec_helper.rb"
+  end
+end

--- a/spec/acceptance/questions/remove_files_from_question_spec.rb
+++ b/spec/acceptance/questions/remove_files_from_question_spec.rb
@@ -16,6 +16,7 @@ feature 'Remove files from question', %q{
 
     within("#attachment1") do
       click_on 'remove file'
+      wait_for_ajax
     end
     expect(page).to_not have_link "spec_helper.rb"
   end

--- a/spec/acceptance/questions/remove_files_from_question_spec.rb
+++ b/spec/acceptance/questions/remove_files_from_question_spec.rb
@@ -1,0 +1,33 @@
+require 'acceptance/acceptance_helper'
+
+feature 'Remove files from question', %q{
+  I order to be able remove file from my question
+  As an author of question
+  I want to be remove files from question
+} do
+
+  given!(:user) { create(:user) }
+  given!(:question) { create(:question_with_attachments, count: 1) }
+
+  scenario 'Author delete files from question', js: true do
+    sign_in(question.user)
+
+    visit question_path(question)
+
+    within("#attachment1") do
+      click_on 'remove file'
+    end
+    expect(page).to_not have_link "spec_helper.rb"
+  end
+
+  scenario 'Non-author can\'t delete files from question', js: true do
+    expect(question.user).to_not eq user
+    sign_in(user)
+
+    visit question_path(question)
+
+    within("#attachments1") do
+      expect(page).to_not have_link"remove file"
+    end
+  end
+end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe AttachmentsController, type: :controller do
+  describe 'DELETE #destroy' do
+    sign_in_user
+
+    let!(:question) { create(:question, user: @user) }
+    let!(:attachment) { create(:attachment, attachable: question) }
+
+    it 'assigns the requested attachment to @attachment' do
+      delete :destroy, params: {id: attachment, format: :js}
+      expect(assigns(:attachment)).to eq attachment
+    end
+
+    it 'delete attachment of question' do
+      expect {delete :destroy, params: {id: attachment, format: :js}}.to change(Attachment, :count).by(-1)
+    end
+
+    it 'user can not delete attachament of other author' do
+      attachment = create(:attachment, attachable: create(:question, user: create(:user)))
+      expect {delete :destroy, params: {id: attachment, format: :js}}.to_not change(Attachment, :count)
+    end
+
+    it 'render destroy template' do
+      delete :destroy, params: {id: attachment, format: :js}
+      expect(response).to render_template :destroy
+    end
+  end
+end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe QuestionsController, type: :controller do
       expect(assigns(:question)).to be_a_new(Question)
     end
 
+    it 'build a new Attachment to @question.attachments' do
+      expect(assigns(:question).attachments.first).to be_a_new(Attachment)
+    end
+
     it 'renders new view' do
       expect(response).to render_template :new
     end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe QuestionsController, type: :controller do
       expect(assigns(:question)).to eq question
     end
 
+    it 'build a new Attachment to @answer.attachments' do
+      expect(assigns(:answer).attachments.first).to be_a_new(Attachment)
+    end
+
     it 'renders show view' do
       expect(response).to render_template :show
     end

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -4,6 +4,15 @@ FactoryGirl.define do
     user
     question
     body
+
+    factory :answer_with_attachments do
+      transient do
+        count 5
+      end
+      after :create do |answer, evaluator|
+        FactoryGirl.create_list(:attachment, evaluator.count, attachable: answer)
+      end
+    end
   end
 
   factory :invalid_answer, class: "Answer" do

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :attachment do
+    file "MyString"
+  end
+end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -19,6 +19,14 @@ FactoryGirl.define do
         FactoryGirl.create_list(:answer, evaluator.answers_count, question: question, user: evaluator.user)
       end
     end
+    factory :question_with_attachments do
+      transient do
+        count 5
+      end
+      after :create do |question, evaluator|
+        FactoryGirl.create_list(:attachment, evaluator.count, attachable: question)
+      end
+    end
   end
 
   factory :invalid_question, class: "Question" do

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe Answer do
   it { should belong_to :user}
   it { should belong_to :question}
+  it { should have_many(:attachments).dependent(:destroy) }
+  it { should accept_nested_attributes_for :attachments }
   it { should validate_presence_of :body}
   it { should have_db_column(:accept) }
 

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -13,9 +13,12 @@ describe Answer do
     let!(:answer1) { create(:answer, question: question, id: 3) }
     let!(:answer2) { create(:answer, question: question, accept: true, id: 2) }
     let!(:answer3) { create(:answer, question: question, id: 1) }
+    let!(:answer4) { create(:answer, question: question, accept: true) }
 
     context 'with valid attributes'  do
       context 'accept answer1' do
+        it { expect { answer4.accept! }.to_not change { answer4.reload.accept }.from(true) }
+        it { expect { answer4.accept! }.to change { answer2.reload.accept }.from(true).to(false) }
         it { expect { answer1.accept! }.to change { answer1.reload.accept }.from(false).to(true) }
         it { expect { answer1.accept! }.to change { answer2.reload.accept }.from(true).to(false) }
         it { expect { answer1.accept! }.to_not change { answer3.reload.accept }.from(false) }

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Attachment, type: :model do
+  it { should belong_to :attachable}
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe Question do
   it { should belong_to :user}
   it { should have_many(:answers).dependent(:destroy)}
+  it { should have_many(:attachments).dependent(:destroy) }
   it { should validate_presence_of :title}
   it { should validate_presence_of :body}
+  it { should accept_nested_attributes_for :attachments }
 end


### PR DESCRIPTION
- Реализовать добавление файлов к вопросам и ответам
- Реализовать возможность добавления нескольких файлов при создании вопроса или ответа. Для реализации можно использовать gem cocoon (github.com).
- Для вопросов/ответов, созданных с прикрепленными файлами, должна быть возможность удаления каждого из прикрепленных файлов. Удалить файл может только автор вопроса/ответа, к которому прикреплен данный файл.