### PR TITLE
Task12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,8 @@ gem 'cocoon'
 #gem 'skim'
 #gem 'gon'
 gem 'toastr-rails'
-
+gem 'omniauth'
+gem 'omniauth-facebook'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'cocoon'
 gem 'toastr-rails'
 gem 'omniauth'
 gem 'omniauth-facebook'
+gem 'omniauth-twitter'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development, :test do
   gem 'capybara-webkit'
   gem 'database_cleaner'
   gem 'rspec-json_expectations'
+  gem 'capybara-email'
 end
 
 group :development do
@@ -70,6 +71,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'letter_opener'
 end
 
 group :test do

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,16 @@
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def facebook
+    @user = User.find_for_omniauth(request.env['omniauth.auth'])
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "Facebook") if is_navigational_format?
+    else
+      session["devise.facebook_data"] = request.env['omniauth.auth']
+      redirect_to new_user_registration_url
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,21 +1,10 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  def self.providers_callback_for(provider)
-    class_eval %Q{
-      def #{provider}
-        @user = User.find_for_omniauth(request.env['omniauth.auth'])
-        if @user.persisted?
-          sign_in_and_redirect @user, event: :authentication
-          set_flash_message(:notice, :success, kind: "#{provider.capitalize}") if is_navigational_format?
-        else
-          session["devise.#{provider}_data"] = request.env['omniauth.auth']
-          redirect_to new_user_registration_url
-        end
-      end
-    }
+  def facebook
+    provider_callback(:facebook)
   end
 
-  Devise.omniauth_providers.each do |provider|
-    providers_callback_for(provider)
+  def twitter
+    provider_callback(:twitter)
   end
 
   def after_sign_in_path_for(resource)
@@ -29,5 +18,18 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def failure
     redirect_to root_path
+  end
+
+  private
+
+  def provider_callback(provider)
+    @user = User.find_for_omniauth(request.env['omniauth.auth'])
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "#{provider.capitalize}") if is_navigational_format?
+    else
+      session["devise.#{provider}_data"] = request.env['omniauth.auth']
+      redirect_to new_user_registration_url
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,18 +3,14 @@ class UsersController < ApplicationController
 
   def finish_signup
     if request.patch? && user_params[:email]
-      email = user_params[:email]
-      user = User.find_by_email(email)
-      if user
-        user.authorizations << @user.authorizations
-        user.save
-        @user.destroy
-        sign_in user
-        redirect_to root_path, notice: t("devise.sessions.signed_in")
-      else
-        if @user.update(user_params.merge(confirmed_at: nil))
-          @user.send_confirmation_instructions
-          sign_in_and_redirect @user, event: :authentication
+      user_status = @user.update_params(user_params)
+      if user_status
+        case user_status[:status]
+          when :new
+            sign_in_and_redirect user_status[:user], event: :authentication
+          when :existing
+            sign_in user_status[:user]
+            redirect_to root_path, notice: t("devise.sessions.signed_in")
         end
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,32 @@
+class UsersController < ApplicationController
+  before_action :load_user, only: [:finish_signup]
+
+  def finish_signup
+    if request.patch? && user_params[:email]
+      email = user_params[:email]
+      user = User.find_by_email(email)
+      if user
+        user.authorizations << @user.authorizations
+        user.save
+        @user.destroy
+        sign_in user
+        redirect_to root_path, notice: t("devise.sessions.signed_in")
+      else
+        if @user.update(user_params.merge(confirmed_at: nil))
+          @user.send_confirmation_instructions
+          sign_in_and_redirect @user, event: :authentication
+        end
+      end
+    end
+  end
+
+  private
+
+  def load_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:email)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,16 +2,20 @@ class UsersController < ApplicationController
   before_action :load_user, only: [:finish_signup]
 
   def finish_signup
-    if request.patch? && user_params[:email]
-      user_status = @user.update_params(user_params)
-      if user_status
-        case user_status[:status]
-          when :new
-            sign_in_and_redirect user_status[:user], event: :authentication
-          when :existing
-            sign_in user_status[:user]
-            redirect_to root_path, notice: t("devise.sessions.signed_in")
+    if request.patch?
+      if user_params[:email].present?
+        user_status = @user.update_params(user_params)
+        if user_status
+          case user_status[:status]
+            when :new
+              sign_in_and_redirect user_status[:user], event: :authentication
+            when :existing
+              sign_in user_status[:user]
+              redirect_to root_path, notice: t("devise.sessions.signed_in")
+          end
         end
+      else
+        @user.errors.add(:base, "Email can't be blank")
       end
     end
   end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,0 +1,5 @@
+class Authorization < ApplicationRecord
+  belongs_to :user
+
+  validates :provider, :uid, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,27 @@
 class User < ApplicationRecord
   has_many :questions, dependent: :destroy
   has_many :answers, dependent: :destroy
+  has_many :authorizations, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable,
+         :omniauthable, omniauth_providers: [:facebook]
 
   def author_of?(model)
     model.user_id == id if model.respond_to?(:user_id)
+  end
+
+  def self.find_for_omniauth(auth)
+    authorization = Authorization.where(provider: auth.provider, uid: auth.uid).first
+    return authorization.user if authorization
+
+    user = User.where(email: auth.info.email).first
+    unless user
+      password = Devise.friendly_token[0,20]
+      user = User.create!(email: auth.info.email, password: password, password_confirmation: password)
+    end
+    user.authorizations.create(provider: auth.provider, uid: auth.uid)
+    user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  TEMP_EMAIL_PREFIX = 'qna2017@me'
+  TEMP_EMAIL_REGEX = /\Aqna2017@me/
+
   has_many :questions, dependent: :destroy
   has_many :answers, dependent: :destroy
   has_many :authorizations, dependent: :destroy
@@ -6,7 +9,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable,
-         :omniauthable, omniauth_providers: [:facebook]
+         :omniauthable, omniauth_providers: [:facebook, :twitter]
+
 
   def author_of?(model)
     model.user_id == id if model.respond_to?(:user_id)
@@ -15,13 +19,29 @@ class User < ApplicationRecord
   def self.find_for_omniauth(auth)
     authorization = Authorization.where(provider: auth.provider, uid: auth.uid).first
     return authorization.user if authorization
-
-    user = User.where(email: auth.info.email).first
+    email = auth.info.email.nil? || auth.info.email.empty? ? create_temp_email(auth) : auth.info.email
+    user = User.where(email: email).first
     unless user
       password = Devise.friendly_token[0,20]
-      user = User.create!(email: auth.info.email, password: password, password_confirmation: password)
+      user = User.new(email: email, password: password, password_confirmation: password)
+      if user.temp_email?
+        user.skip_confirmation!
+      end
+      user.save
     end
     user.authorizations.create(provider: auth.provider, uid: auth.uid)
     user
+  end
+
+  def self.create_temp_email(auth)
+    "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com"
+  end
+
+  def email_verified?
+    !(self.email.empty? || temp_email?)
+  end
+
+  def temp_email?
+    self.email.match?(TEMP_EMAIL_REGEX)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_many :authorizations, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable,
          :omniauthable, omniauth_providers: [:facebook]
 

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/finish_signup.html.erb
+++ b/app/views/users/finish_signup.html.erb
@@ -1,0 +1,22 @@
+<div id="add-email" class="container">
+  <h1>Add Email</h1>
+  <%= form_for(current_user, :as => 'user', :url => finish_signup_path(current_user), :html => { role: 'form'}) do |f| %>
+      <% if current_user.errors.any? %>
+          <div id="error_explanation">
+            <% current_user.errors.full_messages.each do |msg| %>
+                <%= msg %><br>
+            <% end %>
+          </div>
+      <% end %>
+      <div class="form-group">
+        <%= f.label :email %>
+        <div class="controls">
+          <%= f.text_field :email, :autofocus => true, :value => '', class: 'form-control input-lg', placeholder: 'Example: email@me.com' %>
+          <p class="help-block">Please confirm your email address. No spam.</p>
+        </div>
+      </div>
+      <div class="actions">
+        <%= f.submit 'Continue', :class => 'btn btn-primary' %>
+      </div>
+  <% end %>
+</div>

--- a/app/views/users/finish_signup.html.erb
+++ b/app/views/users/finish_signup.html.erb
@@ -1,9 +1,9 @@
 <div id="add-email" class="container">
   <h1>Add Email</h1>
-  <%= form_for(current_user, :as => 'user', :url => finish_signup_path(current_user), :html => { role: 'form'}) do |f| %>
-      <% if current_user.errors.any? %>
+  <%= form_for(@user, :as => 'user', :url => finish_signup_path(@user), :html => { role: 'form'}) do |f| %>
+      <% if @user.errors.any? %>
           <div id="error_explanation">
-            <% current_user.errors.full_messages.each do |msg| %>
+            <% @user.errors.full_messages.each do |msg| %>
                 <%= msg %><br>
             <% end %>
           </div>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/users/mailer/email_changed.html.erb
+++ b/app/views/users/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/users/mailer/password_change.html.erb
+++ b/app/views/users/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/users/mailer/unlock_instructions.html.erb
+++ b/app/views/users/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<h2>Sign up</h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,6 +26,7 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  config.action_mailer.delivery_method = :letter_opener
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   
   # config.logger = Logger.new(STDOUT)
+  config.action_mailer.default_url_options = { host: "localhost:3000" }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -250,7 +250,9 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :facebook, Rails.application.secrets.facebook_app_id,
+                             Rails.application.secrets.facebook_app_secret,
+                             scope: [:email]
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -122,7 +122,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming their account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 0.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
@@ -136,10 +136,10 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
-  # config.confirmation_keys = [:email]
+  config.confirmation_keys = [:email]
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
@@ -252,6 +252,10 @@ Devise.setup do |config|
   # up on your models and hooks.
   config.omniauth :facebook, Rails.application.secrets.facebook_app_id,
                              Rails.application.secrets.facebook_app_secret,
+                             scope: [:email]
+
+  config.omniauth :twitter, Rails.application.secrets.twitter_app_key,
+                             Rails.application.secrets.twitter_app_secret,
                              scope: [:email]
 
   # ==> Warden configuration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: 'omniauth_callbacks' }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   concern :votable do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,7 @@ Rails.application.routes.draw do
 
   resources :attachments, only: [:destroy]
 
+  match '/users/:id/finish_signup' => 'users#finish_signup', via: [:get, :patch], as: :finish_signup
+
   root 'questions#index'
 end

--- a/db/migrate/20170711092526_create_authorizations.rb
+++ b/db/migrate/20170711092526_create_authorizations.rb
@@ -1,0 +1,12 @@
+class CreateAuthorizations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :authorizations do |t|
+      t.references :user, foreign_key: true
+      t.string :provider
+      t.string :uid
+
+      t.timestamps
+    end
+    add_index :authorizations, [:provider, :uid]
+  end
+end

--- a/db/migrate/20170711112830_add_confirmable_to_devise.rb
+++ b/db/migrate/20170711112830_add_confirmable_to_devise.rb
@@ -1,0 +1,23 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[5.1]
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :users, :confirmation_token, unique: true
+    # User.reset_column_information # Need for some types of updates, but not for update_all.
+    # To avoid a short time window between running the migration and updating all existing
+    # users as confirmed, do the following
+    execute("UPDATE users SET confirmed_at = NOW()")
+    # All existing user accounts should be able to log in after this.
+    # Remind: Rails using SQLite as default. And SQLite has no such function :NOW.
+    # Use :date('now') instead of :NOW when using SQLite.
+    # => execute("UPDATE users SET confirmed_at = date('now')")
+    # Or => User.all.update_all confirmed_at: Time.now
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+    remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170711092526) do
+ActiveRecord::Schema.define(version: 20170711112830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,11 @@ ActiveRecord::Schema.define(version: 20170711092526) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170704111327) do
+ActiveRecord::Schema.define(version: 20170711092526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,16 @@ ActiveRecord::Schema.define(version: 20170704111327) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type"
+  end
+
+  create_table "authorizations", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "provider"
+    t.string "uid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authorizations_on_provider_and_uid"
+    t.index ["user_id"], name: "index_authorizations_on_user_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -89,6 +99,7 @@ ActiveRecord::Schema.define(version: 20170704111327) do
 
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "users"
+  add_foreign_key "authorizations", "users"
   add_foreign_key "comments", "users"
   add_foreign_key "questions", "users"
   add_foreign_key "votes", "users"

--- a/spec/acceptance/acceptance_helper.rb
+++ b/spec/acceptance/acceptance_helper.rb
@@ -7,6 +7,7 @@ Capybara.default_max_wait_time = 5
 RSpec.configure do |config|
   config.include AcceptanceMacros, type: :feature
   config.include WaitForAjax, type: :feature
+  config.include OmniauthMacros, type: :feature
 
   config.use_transactional_fixtures = false
 

--- a/spec/acceptance/omniauth_spec.rb
+++ b/spec/acceptance/omniauth_spec.rb
@@ -36,6 +36,20 @@ feature 'Omniauth authorization', %q{
     end
 
     describe "User try login from Facebook with empty email" do
+      scenario "denied to fill an empty email" do
+        visit new_user_session_path
+        expect(page).to have_link "Sign in with Facebook"
+
+        auth = omniauth_mock(:facebook, email: "")
+        click_on "Sign in with Facebook"
+
+        expect(page).to have_content "Please confirm your email address"
+        fill_in 'Email', with: ""
+        click_on "Continue"
+
+        expect(page).to have_content("Email can't be blank")
+      end
+
       scenario "existing user" do
         visit new_user_session_path
         expect(page).to have_link "Sign in with Facebook"

--- a/spec/acceptance/omniauth_spec.rb
+++ b/spec/acceptance/omniauth_spec.rb
@@ -7,13 +7,177 @@ feature 'Omniauth authorization', %q{
 } do
   given!(:user) { create(:user) }
 
-  scenario "Authorization from Facebook" do
-    visit new_user_session_path
-    expect(page).to have_link "Sign in with Facebook"
+  describe "Authorization from Facebook" do
+    scenario "Existing user try login from facebook with identical email" do
+      visit new_user_session_path
+      expect(page).to have_link "Sign in with Facebook"
 
-    omniauth_mock
+      auth = omniauth_mock(:facebook, email: user.email)
+      click_on "Sign in with Facebook"
 
-    click_on "Sign in with Facebook"
-    expect(page).to have_content "Successfully authenticated from Facebook account"
+      expect(page).to have_content "Successfully authenticated from Facebook account"
+    end
+
+    scenario "Existing user try login from social network with other email" do
+      #user.skip_confirmation!
+      visit new_user_session_path
+      expect(page).to have_link "Sign in with Facebook"
+
+      auth = omniauth_mock(:facebook)
+      expect(auth.info.email).to_not eq user.email
+      click_on "Sign in with Facebook"
+
+      expect(page).to have_content("You have to confirm your email address before continuing")
+      open_email(auth.info.email)
+      current_email.click_link 'Confirm my account'
+      expect(page).to have_content 'Your email address has been successfully confirmed.'
+
+      click_on "Sign in with Facebook"
+      expect(page).to have_content "Successfully authenticated from Facebook account"
+    end
+
+    describe "User try login from Facebook with empty email" do
+      scenario "existing user" do
+        visit new_user_session_path
+        expect(page).to have_link "Sign in with Facebook"
+
+        users_count = User.count
+
+        auth = omniauth_mock(:facebook, email: "")
+        expect(auth.info.email).to eq ""
+        click_on "Sign in with Facebook"
+        expect(users_count+1).to eq User.count
+
+        expect(page).to have_content "Please confirm your email address"
+        fill_in 'Email', with: user.email
+        click_on "Continue"
+        expect(users_count).to eq User.count
+
+        expect(page).to_not have_content("You have to confirm your email address before continuing")
+        expect(page).to have_content "Signed in successfully."
+      end
+
+      describe "new user" do
+        scenario "full authenticate" do
+          visit new_user_session_path
+          expect(page).to have_link "Sign in with Facebook"
+
+          users_count = User.count
+
+          auth = omniauth_mock(:facebook, email: "")
+          expect(auth.info.email).to eq ""
+          click_on "Sign in with Facebook"
+          expect(users_count+1).to eq User.count
+
+          expect(page).to have_content "Please confirm your email address"
+          email = "new@dfdsfdsfsd.com"
+          fill_in 'Email', with: email
+          click_on "Continue"
+          expect(users_count+1).to eq User.count
+
+          expect(page).to have_content("You have to confirm your email address before continuing")
+          open_email(email)
+          current_email.click_link 'Confirm my account'
+          expect(page).to have_content 'Your email address has been successfully confirmed.'
+
+          click_on "Sign in with Facebook"
+          expect(page).to have_content "Successfully authenticated from Facebook account."
+        end
+
+        scenario "with temporary e-mail goes to the e-mail form" do
+          auth = omniauth_mock(:facebook, email: "")
+          temp_mail = User.create_temp_email(auth)
+          user.update(email: temp_mail)
+          users_count = User.count
+
+          visit new_user_session_path
+          click_on "Sign in with Facebook"
+          expect(users_count).to eq User.count
+
+          expect(page).to have_content "Please confirm your email address"
+          email = "new@dfdsfdsfsd.com"
+          fill_in 'Email', with: email
+          click_on "Continue"
+
+          expect(page).to have_content("You have to confirm your email address before continuing")
+          open_email(email)
+          current_email.click_link 'Confirm my account'
+          expect(page).to have_content 'Your email address has been successfully confirmed.'
+
+          click_on "Sign in with Facebook"
+          expect(page).to have_content "Successfully authenticated from Facebook account."
+        end
+
+        scenario "login with an unapproved email is prohibited" do
+          auth = omniauth_mock(:facebook, email: "")
+          temp_mail = User.create_temp_email(auth)
+          user.update(email: temp_mail)
+          users_count = User.count
+
+          visit new_user_session_path
+          click_on "Sign in with Facebook"
+          expect(users_count).to eq User.count
+
+          expect(page).to have_content "Please confirm your email address"
+          email = "new@dfdsfdsfsd.com"
+          fill_in 'Email', with: email
+          click_on "Continue"
+
+          visit new_user_session_path
+          click_on "Sign in with Facebook"
+
+          expect(page).to have_content("You have to confirm your email address before continuing")
+        end
+      end
+    end
+
+    describe "User try login from Twitter with empty email" do
+      scenario "existing user" do
+        visit new_user_session_path
+        expect(page).to have_link "Sign in with Twitter"
+
+        users_count = User.count
+
+        auth = omniauth_mock(:twitter, email: "")
+        expect(auth.info.email).to eq ""
+        click_on "Sign in with Twitter"
+        expect(users_count+1).to eq User.count
+
+        expect(page).to have_content "Please confirm your email address"
+        fill_in 'Email', with: user.email
+        click_on "Continue"
+        expect(users_count).to eq User.count
+
+        expect(page).to_not have_content("You have to confirm your email address before continuing")
+        expect(page).to have_content "Signed in successfully."
+      end
+
+      scenario "new user" do
+        visit new_user_session_path
+        expect(page).to have_link "Sign in with Twitter"
+
+        users_count = User.count
+
+        auth = omniauth_mock(:twitter, email: "")
+        expect(auth.info.email).to eq ""
+        click_on "Sign in with Twitter"
+        expect(users_count+1).to eq User.count
+
+        expect(page).to have_content "Please confirm your email address"
+        email = "new@dfdsfdsfsd.com"
+        fill_in 'Email', with: email
+        click_on "Continue"
+        expect(users_count+1).to eq User.count
+
+        expect(page).to have_content("You have to confirm your email address before continuing")
+        open_email(email)
+        current_email.click_link 'Confirm my account'
+        expect(page).to have_content 'Your email address has been successfully confirmed.'
+
+        click_on "Sign in with Twitter"
+        expect(page).to have_content "Successfully authenticated from Twitter account."
+      end
+    end
+
   end
 end

--- a/spec/acceptance/omniauth_spec.rb
+++ b/spec/acceptance/omniauth_spec.rb
@@ -1,0 +1,19 @@
+require 'acceptance/acceptance_helper'
+
+feature 'Omniauth authorization', %q{
+  In order to be able authorization from social network
+  As an user
+  I want to be able to sign in from social network
+} do
+  given!(:user) { create(:user) }
+
+  scenario "Authorization from Facebook" do
+    visit new_user_session_path
+    expect(page).to have_link "Sign in with Facebook"
+
+    omniauth_mock
+
+    click_on "Sign in with Facebook"
+    expect(page).to have_content "Successfully authenticated from Facebook account"
+  end
+end

--- a/spec/acceptance/omniauth_spec.rb
+++ b/spec/acceptance/omniauth_spec.rb
@@ -19,7 +19,6 @@ feature 'Omniauth authorization', %q{
     end
 
     scenario "Existing user try login from social network with other email" do
-      #user.skip_confirmation!
       visit new_user_session_path
       expect(page).to have_link "Sign in with Facebook"
 

--- a/spec/acceptance/sign_up_spec.rb
+++ b/spec/acceptance/sign_up_spec.rb
@@ -23,8 +23,17 @@ feature 'User sign up', %q{
     fill_in 'Password', with: '12345678'
     fill_in 'Password confirmation', with: '12345678'
     click_on 'Sign up'
+    expect(page).to have_content "A message with a confirmation link has been sent to your email address"
 
-    expect(page).to have_content 'You have signed up successfully.'
+    open_email('new_user@test.com')
+    current_email.click_link 'Confirm my account'
+    expect(page).to have_content 'Your email address has been successfully confirmed.'
+
+    fill_in 'Email', with: 'new_user@test.com'
+    fill_in 'Password', with: '12345678'
+    click_on 'Log in'
+
+    expect(page).to have_content 'Signed in successfully.'
   end
 
   scenario 'Non-registered user try to sign up with invalid data' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+  let!(:user) { create(:user) }
+
+  describe "GET #finish_signup" do
+    before do
+      sign_in user
+      get :finish_signup, params: { id: user.id }
+    end
+
+    it 'assigns the requested user to @user' do
+      expect(assigns(:user)).to eq user
+    end
+
+    it 'render finish signup form' do
+      expect(response).to render_template :finish_signup
+    end
+  end
+
+  describe "PATCH #finish_signup" do
+    before do
+      sign_in user
+      patch :finish_signup, params: { id: user.id, user: { email: "new@test.com" } }
+    end
+
+    it 'assigns the requested user to @user' do
+      expect(assigns(:user)).to eq user
+    end
+
+    it 'change user attributes' do
+      user.reload
+      expect(user.email).to eq "new@test.com"
+    end
+
+    it 'redirect to confirmation email path' do
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -19,22 +19,32 @@ RSpec.describe UsersController, type: :controller do
   end
 
   describe "PATCH #finish_signup" do
-    before do
-      sign_in user
-      patch :finish_signup, params: { id: user.id, user: { email: "new@test.com" } }
+    describe "with valid parameters" do
+      before do
+        sign_in user
+        patch :finish_signup, params: { id: user.id, user: { email: "new@test.com" } }
+      end
+
+      it 'assigns the requested user to @user' do
+        expect(assigns(:user)).to eq user
+      end
+
+      it 'change user attributes' do
+        user.reload
+        expect(user.email).to eq "new@test.com"
+      end
+
+      it 'redirect to confirmation email path' do
+        expect(response).to redirect_to new_user_session_path
+      end
     end
 
-    it 'assigns the requested user to @user' do
-      expect(assigns(:user)).to eq user
-    end
-
-    it 'change user attributes' do
-      user.reload
-      expect(user.email).to eq "new@test.com"
-    end
-
-    it 'redirect to confirmation email path' do
-      expect(response).to redirect_to new_user_session_path
+    describe "with invalid parameters" do
+      it "empty email" do
+        sign_in user
+        patch :finish_signup, params: { id: user.id, user: { email: "" } }
+        expect(assigns(:user).errors.full_messages.first).to eq "Email can't be blank"
+      end
     end
   end
 

--- a/spec/factories/authorizations.rb
+++ b/spec/factories/authorizations.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :authorization do
+    user nil
+    provider "MyString"
+    uid "MyString"
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
   factory :user do
     email
     password "123456789"
+    confirmed_at Time.now
   end
 end

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Authorization, type: :model do
+  it { should belong_to :user}
+  it { should validate_presence_of :provider}
+  it { should validate_presence_of :uid}
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   it { should have_many(:questions).dependent(:destroy)}
   it { should have_many(:answers).dependent(:destroy)}
+  it { should have_many(:authorizations).dependent(:destroy)}
   it { should validate_presence_of :email}
   it { should validate_presence_of :password}
 
@@ -32,6 +33,69 @@ RSpec.describe User, type: :model do
 
       it 'fake model without field user_id' do
         expect(user).to_not be_author_of("")
+      end
+    end
+  end
+
+  describe ".find_for_oauth" do
+    let!(:user) { create(:user) }
+    let(:auth) { OmniAuth::AuthHash.new(provider: "facebook", uid: "123456") }
+
+    context "user already has authorization" do
+      it "returns the user" do
+        user.authorizations.create(provider: auth.provider, uid: auth.uid)
+        expect(User.find_for_omniauth(auth)).to eq user
+      end
+    end
+
+    context "user has not authorization" do
+      context "user already exists" do
+        let(:auth) { OmniAuth::AuthHash.new(provider: "facebook", uid: "123456", info: { email: user.email })}
+
+        it "does not create new user" do
+          expect{ User.find_for_omniauth(auth) }.to_not change(User, :count)
+        end
+
+        it "creates new record for authorization" do
+          expect{ User.find_for_omniauth(auth) }.to change(Authorization, :count).by(1)
+        end
+
+        it "creates authorization with provider and uid" do
+          authorization = User.find_for_omniauth(auth).authorizations.first
+          expect(authorization.provider).to eq auth.provider
+          expect(authorization.uid).to eq auth.uid
+        end
+
+        it "returns the user" do
+          expect(User.find_for_omniauth(auth)).to be_a(User)
+        end
+      end
+
+      context "user does not exists" do
+        let(:auth) { OmniAuth::AuthHash.new(provider: "facebook", uid: "123456", info: { email: "new@user.com" })}
+
+        it "create new record user" do
+          expect{ User.find_for_omniauth(auth) }.to change(User, :count).by(1)
+        end
+
+        it "returns new user" do
+          expect(User.find_for_omniauth(auth)).to be_a(User)
+        end
+
+        it "fills user email" do
+          user = User.find_for_omniauth(auth)
+          expect(user.email).to eq auth.info.email
+        end
+
+        it "creates new record for authorization" do
+          expect{ User.find_for_omniauth(auth) }.to change(Authorization, :count).by(1)
+        end
+
+        it "creates authorization with provider and uid" do
+          authorization = User.find_for_omniauth(auth).authorizations.first
+          expect(authorization.provider).to eq auth.provider
+          expect(authorization.uid).to eq auth.uid
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require "rspec/json_expectations"
+require 'capybara/email/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -1,7 +1,11 @@
 module OmniauthMacros
-  def omniauth_mock
+  def omniauth_mock(provider, **args)
     OmniAuth.config.test_mode = true
-    OmniAuth.config.add_mock(:facebook, { uid: '12345', info: { email: "new@user.com" } })
-    OmniAuth.config.mock_auth[:facebook]
+    OmniAuth.config.add_mock(provider, { uid: args[:uid] ? args[:uid] : '12345',
+                                         info: {
+                                             email: args[:email] ? args[:email] : "new@user.com"
+                                         }
+    })
+    OmniAuth.config.mock_auth[provider]
   end
 end

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -1,0 +1,7 @@
+module OmniauthMacros
+  def omniauth_mock
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.add_mock(:facebook, { uid: '12345', info: { email: "new@user.com" } })
+    OmniAuth.config.mock_auth[:facebook]
+  end
+end


### PR DESCRIPTION
    
- Реализовать аутентификацию через Facebook и Twitter. При аутентификации через Twitter запрашивать email пользователя дополнительно (только в первый раз). Обязательно покрыть acceptance и unit-тестами (как тестировать описано в доп. материалах к уроку).

    **Усложненное задание:**
    Реализовать обработку случая, когда провайдер не возвращает email (и Fb и другие провайдеры теперь умеют атуентифицировать по номеру телефона, а не по email. По-умолчанию Twitter тоже не возвращает email, поэтому на нем проще всего протестировать):
      В этом случае, в первый раз запросить у пользователя email, а затем отослать на письмо на указанный email со ссылкой на подтверждение этого email. Не аутентифицировать пользователя до тех пор, пока он не подтвердит указанный email. После подтверждения, пользователь может входить через выбранного провайдера без дополнительных запросов на ввод или подтверждение email.